### PR TITLE
Verify response type and fix exception reporting

### DIFF
--- a/genderize/__init__.py
+++ b/genderize/__init__.py
@@ -79,5 +79,3 @@ class Genderize(object):
         @see: get
         """
         return self.get([name], **kwargs)[0]
-
-


### PR DESCRIPTION
Ran into this problem when trying to do a bulk request for around 750 names. The Apache server responded with a 414 request below, and the exceptions from the `json` module confused me so I thought I would help out the next person that runs into this issue. After all, you gets 2500 requests a day, so this quantity isn't _that_ ridiculous if you don't consider how the sausage is made.

``` html
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>414 Request-URI Too Large</title>
</head><body>
<h1>Request-URI Too Large</h1>
<p>The requested URL's length exceeds the capacity
limit for this server.<br />
</p>
<hr>
<address>Apache/2.2.15 (CentOS) Server at vps-1154848-20754.manage.myhosting.com Port 80</address>
</body></html>
```
