### PR TITLE
bug fix: _fixtypes not working as designed

### DIFF
--- a/genderize/__init__.py
+++ b/genderize/__init__.py
@@ -68,7 +68,7 @@ class Genderize(object):
 
         decoded = response.json()
         if response.ok:
-            return [self._fixtypes(data) for data in decoded]
+            return self._fixtypes(decoded)
         else:
             raise GenderizeException(decoded['error'], response.status_code)
 


### PR DESCRIPTION
fixes:
```
<ipython-input-27-8ca8add8b39a> in <module>()
----> 1 genderize.Genderize().get(['Molly'])

/home/me/.virtualenvs/foo/lib/python2.7/site-packages/genderize/__init__.pyc in get(self, names, country_id, language_id)
     71         if response.ok:
     72             print 'decoded', decoded
---> 73             return [self._fixtypes(data) for data in decoded]
     74         else:
     75             raise GenderizeException(decoded['error'], response.status_code)

/home/me/.virtualenvs/foo/lib/python2.7/site-packages/genderize/__init__.pyc in _fixtypes(data)
     38         if 'probability' in data:
     39             print data
---> 40             data['probability'] = float(data['probability'])
     41         return data
     42

TypeError: string indices must be integers
```